### PR TITLE
added support for TLS when proxying via wai

### DIFF
--- a/http-reverse-proxy.cabal
+++ b/http-reverse-proxy.cabal
@@ -1,5 +1,5 @@
 name:                http-reverse-proxy
-version:             0.2.1.2
+version:             0.3.0.0
 synopsis:            Reverse proxy HTTP requests, either over raw sockets or with WAI
 description:         Provides a simple means of reverse-proxying HTTP requests. The raw approach uses the same technique as leveraged by keter, whereas the WAI approach performs full request/response parsing via WAI and http-conduit.
 homepage:            https://github.com/fpco/http-reverse-proxy
@@ -33,6 +33,7 @@ library
                      , data-default
                      , wai-logger
                      , containers
+                     , connection             >= 0.1.3
 
 test-suite test
     type: exitcode-stdio-1.0

--- a/http-reverse-proxy.cabal
+++ b/http-reverse-proxy.cabal
@@ -1,5 +1,5 @@
 name:                http-reverse-proxy
-version:             0.2.1.1
+version:             0.2.1.2
 synopsis:            Reverse proxy HTTP requests, either over raw sockets or with WAI
 description:         Provides a simple means of reverse-proxying HTTP requests. The raw approach uses the same technique as leveraged by keter, whereas the WAI approach performs full request/response parsing via WAI and http-conduit.
 homepage:            https://github.com/fpco/http-reverse-proxy

--- a/test/main.hs
+++ b/test/main.hs
@@ -83,8 +83,8 @@ main = hspec $ do
             let content = "mainApp"
              in withMan $ \manager ->
                 withWApp (const $ return $ responseLBS status200 [] content) $ \port1 ->
-                withWApp (waiProxyTo (const $ return $ WPRProxyDest $ ProxyDest "127.0.0.1" port1) defaultOnExc manager) $ \port2 ->
-                withCApp (rawProxyTo (const $ return $ Right $ ProxyDest "127.0.0.1" port2)) $ \port3 -> do
+                withWApp (waiProxyTo (const $ return $ WPRProxyDest $ ProxyDest "127.0.0.1" port1 False) defaultOnExc manager) $ \port2 ->
+                withCApp (rawProxyTo (const $ return $ Right $ ProxyDest "127.0.0.1" port2 False)) $ \port3 -> do
                     lbs <- HC.simpleHttp $ "http://127.0.0.1:" ++ show port3
                     lbs `shouldBe` content
         it "modified path" $
@@ -95,8 +95,8 @@ main = hspec $ do
                     pdest
              in withMan $ \manager ->
                 withWApp app $ \port1 ->
-                withWApp (waiProxyTo (modReq $ ProxyDest "127.0.0.1" port1) defaultOnExc manager) $ \port2 ->
-                withCApp (rawProxyTo (const $ return $ Right $ ProxyDest "127.0.0.1" port2)) $ \port3 -> do
+                withWApp (waiProxyTo (modReq $ ProxyDest "127.0.0.1" port1 False) defaultOnExc manager) $ \port2 ->
+                withCApp (rawProxyTo (const $ return $ Right $ ProxyDest "127.0.0.1" port2 False)) $ \port3 -> do
                     lbs <- HC.simpleHttp $ "http://127.0.0.1:" ++ show port3
                     S8.concat (L8.toChunks lbs) `shouldBe` content
         it "deals with streaming data" $
@@ -106,7 +106,7 @@ main = hspec $ do
                     liftIO $ threadDelay 10000000
              in withMan $ \manager ->
                 withWApp app $ \port1 ->
-                withWApp (waiProxyTo (const $ return $ WPRProxyDest $ ProxyDest "127.0.0.1" port1) defaultOnExc manager) $ \port2 -> do
+                withWApp (waiProxyTo (const $ return $ WPRProxyDest $ ProxyDest "127.0.0.1" port1 False) defaultOnExc manager) $ \port2 -> do
                     req <- HC.parseUrl $ "http://127.0.0.1:" ++ show port2
                     mbs <- runResourceT $ timeout 1000000 $ do
                         res <- HC.http req manager
@@ -123,7 +123,7 @@ main = hspec $ do
                 show' (Network.Wai.KnownLength i) = S8.pack $ show i
              in withMan $ \manager ->
                 withWApp app $ \port1 ->
-                withWApp (waiProxyTo (const $ return $ WPRProxyDest $ ProxyDest "127.0.0.1" port1) defaultOnExc manager) $ \port2 -> do
+                withWApp (waiProxyTo (const $ return $ WPRProxyDest $ ProxyDest "127.0.0.1" port1 False) defaultOnExc manager) $ \port2 -> do
                     req' <- HC.parseUrl $ "http://127.0.0.1:" ++ show port2
                     let req = req'
                             { HC.requestBody = HC.RequestBodyBS body


### PR DESCRIPTION
Hi Michael - 

I quickly hacked together the ability to reverse proxy to a TLS endpoint (simply enabling the built in support by HTTP.Conduit). I'm not convinced that I've made the changes in the best manner possible, as i've only concentrated on the waiProxyTo functions (not rawProxyTo). Would be cool if you could take a look and see if this approach, or something better could be incorporated into the main project.

Thank you for your great work, I'm a newbie haskeller, but i've learned a great deal going through some of your code (especially ResourceT!) :)

Ciao,
Tom
