### PR TITLE
Changed Data.Default to Data.Default.Class

### DIFF
--- a/Network/HTTP/ReverseProxy.hs
+++ b/Network/HTTP/ReverseProxy.hs
@@ -26,7 +26,7 @@ module Network.HTTP.ReverseProxy
 
 import BasicPrelude
 import Data.Conduit
-import Data.Default (def)
+import Data.Default.Class (def)
 import qualified Network.Wai as WAI
 import qualified Network.HTTP.Client as HC
 import Network.HTTP.Client (BodyReader, brRead)
@@ -43,7 +43,7 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Conduit.Network as DCN
 import Control.Concurrent.MVar.Lifted (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.Lifted (fork, killThread)
-import Data.Default (Default (..))
+import Data.Default.Class (Default (..))
 import Network.Wai.Logger (showSockAddr)
 import Blaze.ByteString.Builder (Builder)
 import qualified Data.Set as Set

--- a/http-reverse-proxy.cabal
+++ b/http-reverse-proxy.cabal
@@ -29,7 +29,7 @@ library
                      , basic-prelude          >= 0.3.5
                      , network
                      , conduit                >= 0.5
-                     , data-default
+                     , data-default-class
                      , wai-logger
                      , resourcet
                      , containers


### PR DESCRIPTION
Hello!  I'm new to Yesod and was trying to build from Hackage today and encountered an issue that required me to do some patching.  I figured I'd submit this pull request to bring it to your attention!

I was trying to build http-reverse-proxy (along with yesod-bin, I'm submitting a similar pull request there) today and noticed breakages when compiling due to a change in http-client from Data.Default to Data.Default.Class in this commit:

https://github.com/snoyberg/http-client/commit/c9fc8fe33af902b9c3904295188d3e0f710bd0c9

I'm not sure if Data.Default.Class or Data.Default is the intended choice for the framework, but I thought I'd bring this to your attention.  As of now I can't build yesod-bin or http-reverse-client because of this issue.  This is a pretty minor change, and I'm not 100% sure of the reason why the upstream change was made, so feel free to take it or leave it for your own purposes.  Thanks for all your hard work on Yesod!
