### PR TITLE
Needs GHC >= 7.6 due to use of LambdaCase

### DIFF
--- a/http-reverse-proxy.cabal
+++ b/http-reverse-proxy.cabal
@@ -15,7 +15,7 @@ extra-source-files:  README.md ChangeLog.md
 library
   exposed-modules:     Network.HTTP.ReverseProxy
   other-modules:       Paths_http_reverse_proxy
-  build-depends:       base                   >= 4         && < 5
+  build-depends:       base                   >= 4.6    && < 5
                      , monad-control          >= 0.3
                      , lifted-base            >= 0.1
                      , text                   >= 0.11


### PR DESCRIPTION
This only applies to the latest release, revised here: https://hackage.haskell.org/package/http-reverse-proxy-0.4.2/revisions/
