### PR TITLE
Bind to 127.0.0.1 only for tests

### DIFF
--- a/test/main.hs
+++ b/test/main.hs
@@ -46,7 +46,7 @@ nextPort = unsafePerformIO $ I.newIORef 15452
 getPort :: IO Int
 getPort = do
     port <- I.atomicModifyIORef nextPort $ \p -> (p + 1, p)
-    esocket <- try $ bindPortTCP port "*4"
+    esocket <- try $ bindPortTCP port "127.0.0.1"
     case esocket of
         Left (_ :: IOException) -> getPort
         Right socket -> do


### PR DESCRIPTION
No reason to bind to all any interface. Later only `127.0.0.1` used for connection.

Exposing anything on external interfaces rise a question about security during test phase of package installation in source-based linux distributives like Exherbo.