### PR TITLE
add `rawTcpProxyTo` 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.4.4
+
+* add `rawTcpProxyTo` which can handle proxying connections without http headers 
+  [#21](https://github.com/fpco/http-reverse-proxy/issues/21) 
+
 ## 0.4.3.3
 
 * `fixReqHeaders` may create weird `x-real-ip` header [#19](https://github.com/fpco/http-reverse-proxy/issues/19)

--- a/http-reverse-proxy.cabal
+++ b/http-reverse-proxy.cabal
@@ -1,5 +1,5 @@
 name:                http-reverse-proxy
-version:             0.4.3.3
+version:             0.4.4
 synopsis:            Reverse proxy HTTP requests, either over raw sockets or with WAI
 description:         Provides a simple means of reverse-proxying HTTP requests. The raw approach uses the same technique as leveraged by keter, whereas the WAI approach performs full request/response parsing via WAI and http-conduit.
 homepage:            https://github.com/fpco/http-reverse-proxy


### PR DESCRIPTION
add `rawTcpProxyTo` which can handle proxying connections without http headers
https://github.com/fpco/http-reverse-proxy/issues/21