### PR TITLE
Add support for proxying to a Unix socket 

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-16.20
+resolver: lts-19.6


### PR DESCRIPTION
The crux of this PR is adding a new constructor to the `ProxyDest` type called `ProxyDestUnix`, and hooking it up to a call to `Data.Conduit.Network.Unix.runUnixClient`.

Happy to add a test or two if you think this could be mergeable. Thanks!