### PR TITLE
waiProxy: don't strip Content-Length in response for HTTP/2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 
+## 0.6.0.2
+
+* Fix docker registry reverse proxying by preserving the 'Content-Length' response header to HTTP/2 and HEAD requests. [#45](https://github.com/fpco/http-reverse-proxy/pull/45)
+
 ## 0.6.0.1
 
 * Introduce a "semi cached body" to let the beginning of a request body be retried [#34](https://github.com/fpco/http-reverse-proxy/issues/34)

--- a/http-reverse-proxy.cabal
+++ b/http-reverse-proxy.cabal
@@ -1,5 +1,5 @@
 name:                http-reverse-proxy
-version:             0.6.0.1
+version:             0.6.0.2
 synopsis:            Reverse proxy HTTP requests, either over raw sockets or with WAI
 description:         Provides a simple means of reverse-proxying HTTP requests. The raw approach uses the same technique as leveraged by keter, whereas the WAI approach performs full request/response parsing via WAI and http-conduit.
 homepage:            https://github.com/fpco/http-reverse-proxy


### PR DESCRIPTION
HTTP/2 (and newer HTTP/3) don't use chunked encoding so it's fine to keep Content-Length header in responses.

Also include cases for HEAD requests and empty-body responses, because in both cases, chunked encoding won't be used.