### PR TITLE
waiProxy: Remove Content-Length for Encoded Responses

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 
+## 0.6.0.3
+
+* Fix a regression introduced in 0.6.0.2: wrong 'Content-Length' header is preserved for responses with encoded content. [#47](https://github.com/fpco/http-reverse-proxy/pull/47)
+
 ## 0.6.0.2
 
 * Fix docker registry reverse proxying by preserving the 'Content-Length' response header to HTTP/2 and HEAD requests. [#45](https://github.com/fpco/http-reverse-proxy/pull/45)

--- a/http-reverse-proxy.cabal
+++ b/http-reverse-proxy.cabal
@@ -1,5 +1,5 @@
 name:                http-reverse-proxy
-version:             0.6.0.2
+version:             0.6.0.3
 synopsis:            Reverse proxy HTTP requests, either over raw sockets or with WAI
 description:         Provides a simple means of reverse-proxying HTTP requests. The raw approach uses the same technique as leveraged by keter, whereas the WAI approach performs full request/response parsing via WAI and http-conduit.
 homepage:            https://github.com/fpco/http-reverse-proxy


### PR DESCRIPTION
This is a proper fix to #45.

In previous merge request (#45), for HTTP/2 connections, Content-Length header is retained in order to avoid problems with Docker client rejecting chunked encoding responses from Docker registry.

However, this approach failed when the upstream response was encoded (e.g. with 'Content-Encoding: gzip' in header). The retained 'Content-Length' header then mismatched the actual content size after decoding.

To fix this, we now strip the Content-Length header if Content-Encoding header is present, along with our existing checks for cases where chunked encoding is not used (HTTP/2 and HEAD requests).